### PR TITLE
Update hugo code to remove future deprecation warnings

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,7 +13,8 @@ languageCode = "en"           # For RSS, view https://www.rssboard.org/rss-langu
 defaultContentLanguage = "en" # For HTML page, now support: en, zh-hans, zh-hant, ja, nl, pl, it
 
 summaryLength = 100 # Custom summary length, add <!--more--> in post file to custom split point
-paginate = 10
+[pagination]
+pagerSize = 10
 
 # googleAnalytics = "UA-000000000-0" # Set your Google Analytics UA here
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,7 +34,7 @@
 <!-- dep -->
 {{ partial "styles.html" . }}
 {{ $options := (dict "targetPath" "assets/css/fuji.min.css" "outputStyle" "compressed") }}
-{{ $style := resources.Get "scss/fuji.scss" | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+{{ $style := resources.Get "scss/fuji.scss" | css.Sass $options | resources.Fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}" />
 {{ with .Site.Params.googleAdsense }}
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-{{ . }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
Fix the following warnings

```
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.

WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.
```